### PR TITLE
Zombie wave

### DIFF
--- a/Assets/Prefab/Zombie Spawner.prefab
+++ b/Assets/Prefab/Zombie Spawner.prefab
@@ -1,0 +1,163 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2762195970663285972
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3310068770541362797}
+  m_Layer: 0
+  m_Name: zombies
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3310068770541362797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2762195970663285972}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6641087636718929912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3336357470988296168
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6641087636718929912}
+  - component: {fileID: 4769002518591370295}
+  - component: {fileID: 7943813501455037298}
+  - component: {fileID: 2954982291650992359}
+  - component: {fileID: 7858766543369939512}
+  m_Layer: 0
+  m_Name: Zombie Spawner
+  m_TagString: ZombieSpawner
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6641087636718929912
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3336357470988296168}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3310068770541362797}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4769002518591370295
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3336357470988296168}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7943813501455037298
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3336357470988296168}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 6699446615349125189, guid: 53b847a663f32a24fae6147fa55a3606, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2954982291650992359
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3336357470988296168}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7858766543369939512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3336357470988296168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NormalZombiePrefab: {fileID: 8623705291632316242, guid: c54ef36929c84f241b6bb61adb2d9e38, type: 3}
+  GiantZombiePrefab: {fileID: 6556743864698764780, guid: 21d02266118d5cf4d9cbe24850ace904, type: 3}
+  RunnerZombiePrefab: {fileID: 4897249556491024747, guid: 703bcb63cda43a3458ff7e95516aa957, type: 3}
+  zombiesStorage: {fileID: 3310068770541362797}
+  OriginalSpawnTime: 10
+  NormalRate: 1
+  GiantRate: 1
+  RunnerRate: 1

--- a/Assets/Prefab/Zombie Spawner.prefab.meta
+++ b/Assets/Prefab/Zombie Spawner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ab55bcb75f9505468547df9ab1c2191
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -680,6 +680,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Giant Zombie
       objectReference: {fileID: 0}
+    - target: {fileID: 6946205097586649241, guid: 21d02266118d5cf4d9cbe24850ace904, type: 3}
+      propertyPath: attackInterval
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 8818000498215639124, guid: 21d02266118d5cf4d9cbe24850ace904, type: 3}
       propertyPath: m_LocalPosition.x
       value: 2.5
@@ -1779,6 +1783,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 74558912}
     m_Modifications:
+    - target: {fileID: 926121638996714604, guid: c54ef36929c84f241b6bb61adb2d9e38, type: 3}
+      propertyPath: attackInterval
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 3577957944674647934, guid: c54ef36929c84f241b6bb61adb2d9e38, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.5
@@ -1954,6 +1962,10 @@ PrefabInstance:
     - target: {fileID: 4897249556491024747, guid: 703bcb63cda43a3458ff7e95516aa957, type: 3}
       propertyPath: m_Name
       value: Runner Zombie
+      objectReference: {fileID: 0}
+    - target: {fileID: 7311194426027955059, guid: 703bcb63cda43a3458ff7e95516aa957, type: 3}
+      propertyPath: attackInterval
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2915,6 +2927,114 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1521269573}
   m_CullTransparentMesh: 1
+--- !u!1 &1523053106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523053110}
+  - component: {fileID: 1523053109}
+  - component: {fileID: 1523053108}
+  - component: {fileID: 1523053107}
+  m_Layer: 0
+  m_Name: EndLine
+  m_TagString: EndLine
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1523053107
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523053106}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1523053108
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523053106}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 15303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1523053109
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523053106}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1523053110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523053106}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.11, y: -0.09, z: 10.63}
+  m_LocalScale: {x: 10, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1555204439
 GameObject:
   m_ObjectHideFlags: 0
@@ -3802,3 +3922,4 @@ SceneRoots:
   - {fileID: 999773814}
   - {fileID: 1570101277}
   - {fileID: 698545770}
+  - {fileID: 1523053110}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -514,6 +514,63 @@ Transform:
   - {fileID: 1500835904}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &76123680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1185516955}
+    m_Modifications:
+    - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_Name
+      value: Zombie Spawner (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
 --- !u!1 &79730503
 GameObject:
   m_ObjectHideFlags: 0
@@ -589,6 +646,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 79730503}
   m_CullTransparentMesh: 1
+--- !u!1001 &81748323
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1185516955}
+    m_Modifications:
+    - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_Name
+      value: Zombie Spawner (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
 --- !u!1 &117117001
 GameObject:
   m_ObjectHideFlags: 0
@@ -882,6 +996,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 378942209}
   m_CullTransparentMesh: 1
+--- !u!1001 &475983428
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1185516955}
+    m_Modifications:
+    - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_Name
+      value: Zombie Spawner (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
 --- !u!1 &488038906
 GameObject:
   m_ObjectHideFlags: 0
@@ -1273,6 +1444,68 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 10, y: 0, z: 10}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &630016011 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 475983428}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &695943440
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1185516955}
+    m_Modifications:
+    - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_Name
+      value: Zombie Spawner (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
 --- !u!1 &698545769
 GameObject:
   m_ObjectHideFlags: 0
@@ -1478,6 +1711,22 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 724439618}
   m_CullTransparentMesh: 1
+--- !u!4 &746202508 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 81748323}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &746202509 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7858766543369939512, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 81748323}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &813243811 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3251599875848258290, guid: 703bcb63cda43a3458ff7e95516aa957, type: 3}
@@ -2590,6 +2839,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1167142122}
   m_CullTransparentMesh: 1
+--- !u!114 &1179129420 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7858766543369939512, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 475983428}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1185516954
 GameObject:
   m_ObjectHideFlags: 0
@@ -2599,6 +2859,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1185516955}
+  - component: {fileID: 1185516956}
   m_Layer: 0
   m_Name: Zombie Spawners
   m_TagString: Untagged
@@ -2620,8 +2881,35 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 1980958130}
+  - {fileID: 1386727935}
+  - {fileID: 746202508}
+  - {fileID: 1989779454}
+  - {fileID: 630016011}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1185516956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1185516954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4358f9db3423d964696d4eb3c8e91962, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  level: 5
+  spawnInterval: 5
+  NormalRate: 1
+  GiantRate: 1
+  RunnerRate: 1
+  spawner_zero: {fileID: 1980958131}
+  spawner_one: {fileID: 2039630235}
+  spawner_two: {fileID: 746202509}
+  spawner_three: {fileID: 1989779455}
+  spawner_four: {fileID: 1179129420}
+  waveDuration: 10
 --- !u!1 &1226634893
 GameObject:
   m_ObjectHideFlags: 0
@@ -2734,6 +3022,11 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 9218221822711795723, guid: 1cd4a9e17c67b9641aa507f86d19c7df, type: 3}
   m_PrefabInstance: {fileID: 11745611}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1386727935 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 76123680}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1428444898
 GameObject:
@@ -3029,42 +3322,11 @@ Transform:
   m_GameObject: {fileID: 1523053106}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.11, y: -0.09, z: 10.63}
-  m_LocalScale: {x: 10, y: 1, z: 1}
+  m_LocalPosition: {x: 0.7, y: -0.09, z: 10.63}
+  m_LocalScale: {x: 55, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1555204439
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1555204440}
-  m_Layer: 0
-  m_Name: zombies
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1555204440
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1555204439}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1980958130}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1570101273
 GameObject:
@@ -3465,136 +3727,38 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1837648161}
   m_CullTransparentMesh: 1
---- !u!1 &1980958125
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!4 &1980958130 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 573877453943232873}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1980958130}
-  - component: {fileID: 1980958129}
-  - component: {fileID: 1980958128}
-  - component: {fileID: 1980958127}
-  - component: {fileID: 1980958126}
-  m_Layer: 0
-  m_Name: Zombie Spawner
-  m_TagString: ZombieSpawner
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1980958126
+--- !u!114 &1980958131 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 7858766543369939512, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 573877453943232873}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980958125}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NormalZombiePrefab: {fileID: 8623705291632316242, guid: c54ef36929c84f241b6bb61adb2d9e38, type: 3}
-  GiantZombiePrefab: {fileID: 6556743864698764780, guid: 21d02266118d5cf4d9cbe24850ace904, type: 3}
-  RunnerZombiePrefab: {fileID: 4897249556491024747, guid: 703bcb63cda43a3458ff7e95516aa957, type: 3}
-  zombiesStorage: {fileID: 1555204440}
-  OriginalSpawnTime: 10
-  NormalRate: 1
-  GiantRate: 1
-  RunnerRate: 1
---- !u!135 &1980958127
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980958125}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 0
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1980958128
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980958125}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 6699446615349125189, guid: 53b847a663f32a24fae6147fa55a3606, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1980958129
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980958125}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1980958130
+--- !u!4 &1989779454 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 695943440}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980958125}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1555204440}
-  m_Father: {fileID: 1185516955}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1989779455 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7858766543369939512, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 695943440}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2015391890
 GameObject:
   m_ObjectHideFlags: 0
@@ -3670,6 +3834,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2015391890}
   m_CullTransparentMesh: 1
+--- !u!114 &2039630235 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7858766543369939512, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+  m_PrefabInstance: {fileID: 76123680}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da11a9d43e1e294791d957b00419ddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2108562980
 GameObject:
   m_ObjectHideFlags: 0
@@ -3837,6 +4012,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8bc1bf87764b29248823395c4ecd03e0, type: 3}
+--- !u!1001 &573877453943232873
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1185516955}
+    m_Modifications:
+    - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_Name
+      value: Zombie Spawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
 --- !u!4 &2375824612336284617 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8298247673097533604, guid: bd4ca08e5f9e376428e401fbaa196381, type: 3}

--- a/Assets/Scripts/Zombie/SpawnerManager.cs
+++ b/Assets/Scripts/Zombie/SpawnerManager.cs
@@ -1,0 +1,125 @@
+using UnityEditor.ShortcutManagement;
+using UnityEngine;
+using System.Collections;
+
+public class SpawnerManager : MonoBehaviour
+{
+    public int level = 5;
+    public float spawnInterval = 5f;
+    public int NormalRate;
+    public int GiantRate;
+    public int RunnerRate;
+    public ZombieSpawner spawner_zero;
+    public ZombieSpawner spawner_one;
+    public ZombieSpawner spawner_two;
+    public ZombieSpawner spawner_three;
+    public ZombieSpawner spawner_four;
+    public float waveDuration;
+    ///////////////////////////////////////
+    private float Timer = 0f;
+    private float spawnTimer = 0f;
+    private int[] rows = { 0, 1, 2, 3, 4 };
+    private int cardinalNum;
+    private bool isWave = false;
+    private int waveTimes = 0;
+
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        GiantRate += NormalRate;
+        RunnerRate += GiantRate;
+        cardinalNum = RunnerRate;
+        int zombiesLayer = LayerMask.NameToLayer("zombies");
+        Physics.IgnoreLayerCollision(zombiesLayer, zombiesLayer, true);
+        Debug.Log("Ignore zombie layer collision");
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (waveTimes < 3) // 3波結束後就不生成殭屍了
+        {
+            if (Timer >= 60f && waveTimes < 3)
+            {
+                isWave = true;
+                StartCoroutine(waveSpawn());
+                Timer = 0f;
+                waveTimes++;
+                Debug.Log("Wave 開始" + waveTimes);
+            }
+            if (spawnTimer >= spawnInterval && !isWave)
+            {
+                SpawnZombie();
+                spawnTimer = 0f;
+            }
+            Timer += Time.deltaTime;
+            if (!isWave) spawnTimer += Time.deltaTime;
+        }
+    }
+
+    private void SpawnZombie()
+    {
+        Shuffle(rows);
+        
+        int zombieNum = (level < 5) ? level: 5; // zombie上限為5隻
+
+        for (int i = 0; i < zombieNum; i++)
+        {
+            int randomTypeNum = Random.Range(0, cardinalNum);
+            int type = 0; // 0 normal // 1 giant // 2 runner
+            if (randomTypeNum < NormalRate)
+                type = 0;
+            else if (randomTypeNum < GiantRate)
+                type = 1;
+            else if (randomTypeNum < RunnerRate)
+                type = 2;
+
+            int rowIndex = rows[i];
+            switch(rowIndex)
+            {
+                case 0:
+                    spawner_zero.SpawnZombie(type);
+                    break;
+                case 1:
+                    spawner_one.SpawnZombie(type);
+                    break;
+                case 2:
+                    spawner_two.SpawnZombie(type);
+                    break;
+                case 3:
+                    spawner_three.SpawnZombie(type);
+                    break;
+                case 4:
+                    spawner_four.SpawnZombie(type);
+                    break;
+            }
+        }
+    }
+
+    private void Shuffle(int[] array)
+    {
+        for (int i = array.Length - 1; i > 0; i--)
+        {
+            int randomIndex = Random.Range(0, i + 1);
+
+            int temp = array[i];
+            array[i] = array[randomIndex];
+            array[randomIndex] = temp;
+        }
+    }
+
+    IEnumerator waveSpawn()
+    {
+        float elapsedTime = 0f;
+
+        while (elapsedTime < waveDuration)
+        {
+            SpawnZombie();
+            yield return new WaitForSeconds(1f); // 等待1秒
+            elapsedTime += 1f;
+        }
+
+        Debug.Log("wave結束");
+        isWave = false;
+    }
+}

--- a/Assets/Scripts/Zombie/SpawnerManager.cs.meta
+++ b/Assets/Scripts/Zombie/SpawnerManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4358f9db3423d964696d4eb3c8e91962

--- a/Assets/Scripts/Zombie/Zombie AI.cs
+++ b/Assets/Scripts/Zombie/Zombie AI.cs
@@ -161,7 +161,7 @@ public class ZombieController : MonoBehaviour
                 animator.SetInteger("state", 1);
                 break;
         }
-        Debug.Log("Zombie State: " + state.ToString());
+        // Debug.Log("Zombie State: " + state.ToString());
     }
 
     public void TakeDamage(float damage)
@@ -230,7 +230,7 @@ public class ZombieController : MonoBehaviour
     {
         while (nut != null)
         {
-            Debug.Log("Zombie attacking");
+            //Debug.Log("Zombie attacking");
             nut.TakeDamage(attack); // 攻擊堅果牆
 
             for (float timer = 0; timer < attackInterval; timer += Time.deltaTime)

--- a/Assets/Scripts/Zombie/ZombieSpawner.cs
+++ b/Assets/Scripts/Zombie/ZombieSpawner.cs
@@ -8,71 +8,71 @@ public class ZombieSpawner : MonoBehaviour
     public GameObject GiantZombiePrefab;
     public GameObject RunnerZombiePrefab;
     public Transform zombiesStorage;
-    public float OriginalSpawnTime;
-    public int NormalRate;
-    public int GiantRate;
-    public int RunnerRate;
-    private float Timer;
-    private int cardinalNum;
-    private Type type;
+    //public float OriginalSpawnTime;
+    //public int NormalRate;
+    //public int GiantRate;
+    //public int RunnerRate;
+    //public Type type;
+    //private float Timer;
+    //private int cardinalNum;
     private LinkedList<GameObject> Zombies;
+    //public enum Type
+    //{
+    //    Normal,
+    //    Giant,
+    //    Runner,
+    //}
 
-    private enum Type
-    {
-        Normal, 
-        Giant, 
-        Runner, 
-    }
     void Start()
     {
-        Timer = 0f;
-        GiantRate += NormalRate;
-        RunnerRate += GiantRate;
-        cardinalNum = RunnerRate;
+        //Timer = 0f;
+        //GiantRate += NormalRate;
+        //RunnerRate += GiantRate;
+        //cardinalNum = RunnerRate;
         Zombies = new LinkedList<GameObject>();
 
-        int zombiesLayer = LayerMask.NameToLayer("zombies");
-        Physics.IgnoreLayerCollision(zombiesLayer, zombiesLayer, true);
-        Debug.Log("Ignore zombie layer collision");
+        //int zombiesLayer = LayerMask.NameToLayer("zombies");
+        //Physics.IgnoreLayerCollision(zombiesLayer, zombiesLayer, true);
+        //Debug.Log("Ignore zombie layer collision");
     }
 
     // Update is called once per frame
     void Update()
     {
-        Timer += Time.deltaTime;
-        if (Timer > OriginalSpawnTime)
-        {
-            Timer = 0f;
-            int randomTypeNum = Random.Range(0, cardinalNum);
-            if (randomTypeNum < NormalRate)
-            {
-                type = Type.Normal;
-            }
-            else if (randomTypeNum < GiantRate)
-            {
-                type = Type.Giant;
-            }
-            else if (randomTypeNum < RunnerRate)
-            {
-                type = Type.Runner;
-            }
-            SpawnZombie();
-        }
+        //Timer += Time.deltaTime;
+        //if (Timer > OriginalSpawnTime)
+        //{
+        //    Timer = 0f;
+        //    int randomTypeNum = Random.Range(0, cardinalNum);
+        //    if (randomTypeNum < NormalRate)
+        //    {
+        //        type = Type.Normal;
+        //    }
+        //    else if (randomTypeNum < GiantRate)
+        //    {
+        //        type = Type.Giant;
+        //    }
+        //    else if (randomTypeNum < RunnerRate)
+        //    {
+        //        type = Type.Runner;
+        //    }
+        //    SpawnZombie(type);
+        //}
     }
 
-    private void SpawnZombie()
+    public void SpawnZombie(int type)
     {
         Debug.Log("Create Zombie: " + type);
         GameObject zombie = null;
         switch(type)
         {
-            case Type.Normal:
+            case 0:
                 zombie = Instantiate(NormalZombiePrefab, zombiesStorage.position, zombiesStorage.rotation);
                 break;
-            case Type.Giant:
+            case 1:
                 zombie = Instantiate(GiantZombiePrefab, zombiesStorage.position, zombiesStorage.rotation);
                 break;
-            case Type.Runner:
+            case 2:
                 zombie = Instantiate(RunnerZombiePrefab, zombiesStorage.position, zombiesStorage.rotation);
                 break;
         }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -10,6 +10,7 @@ TagManager:
   - Gun
   - ZombieSpawner
   - item
+  - EndLine
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
基於zombie-attack之上的修改

zombie-attack :
解決zombie攻擊nut的問題，現在殭屍會攻擊nut了，並且在nut消失後會繼續往前走
新增一個 EndLine (tag: EndLine)，殭屍碰到 EndLine 會直接消失，需要將 EndLine 當作房子的最末尾段，殭屍進去會需要扣分(尚未實作)

zombie-wave :
新增5個zombie spawner 並由 spawner manager 管理，並新增殭屍生成波次系統，會根據 level 等級生成
* level 1 ~ 5 : 各自生成 1 ~ 5 隻，level 越高生成數量越多
* level 6 ~ 9 : 皆生成 5 隻，但生成間隔會縮短 1 ~ 4 秒 (尚未處理)

每 1 分鐘會生成一波 wave ，在 wave 狀態下(暫定 10 秒，可調) 會每一秒生成該 level 的生成數量的殭屍 (level 1 : 1 zombie per second, level 2 : 2 zombie per second ...... ) 恩 ! level 9 等於時刻處於wave狀態XD
3波wave過後便不會再生成殭屍，可能需要製作UI來暫停遊戲並讓玩家選擇是否要進行下一level。

測試的時候請把 EndLine 放在 zombieSpawner 的路徑上，不然殭屍數量可能會塞爆電腦 !