### PR TITLE
新增CenterController

### DIFF
--- a/Assets/Prefab/PeaShooter.prefab
+++ b/Assets/Prefab/PeaShooter.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2429814286781858347
+--- !u!1 &1133082269183045266
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,196 +8,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3095028014589483153}
-  - component: {fileID: 9017392964314656023}
-  - component: {fileID: 4943266723554506558}
-  - component: {fileID: 2538335848627492388}
-  m_Layer: 0
-  m_Name: PeaShooter
-  m_TagString: item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3095028014589483153
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2429814286781858347}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19.98763, y: 4.896472, z: 25.207706}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6535356108641397148}
-  - {fileID: 7554782303629585246}
-  - {fileID: 2109856533729304058}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &9017392964314656023
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2429814286781858347}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!65 &4943266723554506558
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2429814286781858347}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 5.2475433, y: 9.02054, z: 6.1651115}
-  m_Center: {x: 1.7822437, y: -1.0810261, z: 0.15312958}
---- !u!114 &2538335848627492388
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2429814286781858347}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 109836bfed9abc34c8d25fed575e6290, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 554377340007153490, guid: a665d79c20999184d8eb16f4e428b699, type: 3}
-  thisCollider: {fileID: 4943266723554506558}
-  attackInterval: 3
-  maxHealth: 100
-  energyCost: 20
-  muzzle: {fileID: 2109856533729304058}
---- !u!1 &6676020010298564844
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6535356108641397148}
-  - component: {fileID: 5108591568762605087}
-  - component: {fileID: 8851132816832846336}
-  m_Layer: 0
-  m_Name: Sphere
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6535356108641397148
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6676020010298564844}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.68464303, y: 0, z: -0, w: 0.7288785}
-  m_LocalPosition: {x: 1.67134, y: 0.056672525, z: -2.1032274}
-  m_LocalScale: {x: 129.81717, y: 129.81717, z: 129.81717}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3095028014589483153}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &5108591568762605087
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6676020010298564844}
-  m_Mesh: {fileID: 4711208715938537054, guid: eb322daac307c3c4989704ffa2981548, type: 3}
---- !u!23 &8851132816832846336
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6676020010298564844}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: -876546973899608171, guid: eb322daac307c3c4989704ffa2981548, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &8912192091405054159
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2109856533729304058}
+  - component: {fileID: 1302513940094205212}
   m_Layer: 0
   m_Name: Muzzle
   m_TagString: Untagged
@@ -205,22 +16,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2109856533729304058
+--- !u!4 &1302513940094205212
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8912192091405054159}
+  m_GameObject: {fileID: 1133082269183045266}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 1.7023029, y: 0.05, z: -2.616}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
+  m_LocalPosition: {x: 0.169, y: 0, z: -0.267}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3095028014589483153}
+  m_Father: {fileID: 4192139899707371647}
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
---- !u!1 &9181251247885236741
+--- !u!1 &1709293676258640086
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -228,9 +39,42 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7554782303629585246}
-  - component: {fileID: 5487878680328531067}
-  - component: {fileID: 6075710760912974765}
+  - component: {fileID: 4192139899707371647}
+  m_Layer: 0
+  m_Name: PeaShooter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4192139899707371647
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709293676258640086}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5280217359977482153}
+  - {fileID: 1302513940094205212}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2786680699161829848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8754750975262687443}
+  - component: {fileID: 6727219309580102787}
+  - component: {fileID: 6388402291949614807}
   m_Layer: 0
   m_Name: Sphere.003
   m_TagString: Untagged
@@ -238,36 +82,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7554782303629585246
+--- !u!4 &8754750975262687443
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9181251247885236741}
+  m_GameObject: {fileID: 2786680699161829848}
   serializedVersion: 2
   m_LocalRotation: {x: -0.68464303, y: 0, z: -0, w: 0.7288785}
   m_LocalPosition: {x: 0.8622775, y: 0.8918888, z: -0.66325957}
   m_LocalScale: {x: 85.92779, y: 85.927795, z: 85.927795}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3095028014589483153}
+  m_Father: {fileID: 5280217359977482153}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &5487878680328531067
+--- !u!33 &6727219309580102787
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9181251247885236741}
+  m_GameObject: {fileID: 2786680699161829848}
   m_Mesh: {fileID: 3447038591770236762, guid: eb322daac307c3c4989704ffa2981548, type: 3}
---- !u!23 &6075710760912974765
+--- !u!23 &6388402291949614807
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9181251247885236741}
+  m_GameObject: {fileID: 2786680699161829848}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -306,3 +150,191 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8001804462796644081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7677191886080428176}
+  - component: {fileID: 4981048394354615772}
+  - component: {fileID: 456288292718008026}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7677191886080428176
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001804462796644081}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.68464303, y: 0, z: -0, w: 0.7288785}
+  m_LocalPosition: {x: 1.67134, y: 0.056672525, z: -2.1032274}
+  m_LocalScale: {x: 129.81717, y: 129.81717, z: 129.81717}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5280217359977482153}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4981048394354615772
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001804462796644081}
+  m_Mesh: {fileID: 4711208715938537054, guid: eb322daac307c3c4989704ffa2981548, type: 3}
+--- !u!23 &456288292718008026
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001804462796644081}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: -876546973899608171, guid: eb322daac307c3c4989704ffa2981548, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8082537863414267646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5280217359977482153}
+  - component: {fileID: 3010848920802259117}
+  - component: {fileID: 6751553534790365307}
+  - component: {fileID: 5146290246945605614}
+  m_Layer: 0
+  m_Name: PeaShooter
+  m_TagString: item
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5280217359977482153
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8082537863414267646}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7677191886080428176}
+  - {fileID: 8754750975262687443}
+  m_Father: {fileID: 4192139899707371647}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &3010848920802259117
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8082537863414267646}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &6751553534790365307
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8082537863414267646}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 5.2475433, y: 9.02054, z: 6.1651115}
+  m_Center: {x: 1.7822437, y: -1.0810261, z: 0.15312958}
+--- !u!114 &5146290246945605614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8082537863414267646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 109836bfed9abc34c8d25fed575e6290, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 554377340007153490, guid: a665d79c20999184d8eb16f4e428b699, type: 3}
+  thisCollider: {fileID: 6751553534790365307}
+  attackInterval: 3
+  maxHealth: 100
+  energyCost: 20
+  muzzle: {fileID: 1302513940094205212}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -524,7 +524,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_Name
-      value: Zombie Spawner (1)
+      value: Zombie Spawner one
       objectReference: {fileID: 0}
     - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_LocalPosition.x
@@ -656,7 +656,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_Name
-      value: Zombie Spawner (2)
+      value: Zombie Spawner zero
       objectReference: {fileID: 0}
     - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1006,7 +1006,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_Name
-      value: Zombie Spawner (4)
+      value: Zombie Spawner four
       objectReference: {fileID: 0}
     - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1459,7 +1459,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_Name
-      value: Zombie Spawner (3)
+      value: Zombie Spawner three
       objectReference: {fileID: 0}
     - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1537,6 +1537,7 @@ Transform:
   m_Children:
   - {fileID: 819702735}
   - {fileID: 1680090277}
+  - {fileID: 1336421105}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
@@ -1811,6 +1812,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 883552362}
+  - component: {fileID: 883552363}
   m_Layer: 0
   m_Name: Center Controller
   m_TagString: Untagged
@@ -1833,6 +1835,21 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &883552363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 883552361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a37fe56153ee66429340838af8608fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  level: 1
+  energy: 100
+  health: 500
 --- !u!1 &890341963
 GameObject:
   m_ObjectHideFlags: 0
@@ -2888,9 +2905,9 @@ Transform:
   m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 1980958130}
-  - {fileID: 1386727935}
   - {fileID: 746202508}
+  - {fileID: 1386727935}
+  - {fileID: 1980958130}
   - {fileID: 1989779454}
   - {fileID: 630016011}
   m_Father: {fileID: 0}
@@ -2907,17 +2924,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4358f9db3423d964696d4eb3c8e91962, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level: 5
   spawnInterval: 10
   NormalRate: 1
   GiantRate: 1
   RunnerRate: 1
-  spawner_zero: {fileID: 1980958131}
+  spawner_zero: {fileID: 746202509}
   spawner_one: {fileID: 2039630235}
-  spawner_two: {fileID: 746202509}
+  spawner_two: {fileID: 1980958131}
   spawner_three: {fileID: 1989779455}
   spawner_four: {fileID: 1179129420}
   waveDuration: 10
+  centerController: {fileID: 883552363}
 --- !u!1 &1226634893
 GameObject:
   m_ObjectHideFlags: 0
@@ -3026,6 +3043,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 20.519, y: 180, z: 0}
+--- !u!4 &1336421105 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+  m_PrefabInstance: {fileID: 3051406187573901210}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1369193843 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9218221822711795723, guid: 1cd4a9e17c67b9641aa507f86d19c7df, type: 3}
@@ -3330,7 +3352,7 @@ Transform:
   m_GameObject: {fileID: 1523053106}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.7, y: -0.09, z: 10.63}
+  m_LocalPosition: {x: 0.7, y: -0.41, z: -14.9}
   m_LocalScale: {x: 55, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3551,67 +3573,6 @@ Transform:
   - {fileID: 2375824612336284617}
   m_Father: {fileID: 1732554619}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1715504713
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2429814286781858347, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_Name
-      value: PeaShooter
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 19.98763
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 4.896472
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 25.207706
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3095028014589483153, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9017392964314656023, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
-      propertyPath: m_IsKinematic
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
 --- !u!1 &1732554618
 GameObject:
   m_ObjectHideFlags: 0
@@ -4099,7 +4060,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3336357470988296168, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_Name
-      value: Zombie Spawner
+      value: Zombie Spawner two
       objectReference: {fileID: 0}
     - target: {fileID: 6641087636718929912, guid: 6ab55bcb75f9505468547df9ab1c2191, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4151,6 +4112,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8298247673097533604, guid: bd4ca08e5f9e376428e401fbaa196381, type: 3}
   m_PrefabInstance: {fileID: 7542491672436329974}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3051406187573901210
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 698545770}
+    m_Modifications:
+    - target: {fileID: 1709293676258640086, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_Name
+      value: PeaShooter
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.37748998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4192139899707371647, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 27c4a3d2f5ab7c646832aeb0f1697c0c, type: 3}
 --- !u!1001 &7542491672436329974
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4232,4 +4250,3 @@ SceneRoots:
   - {fileID: 1570101277}
   - {fileID: 698545770}
   - {fileID: 1523053110}
-  - {fileID: 1715504713}

--- a/Assets/Scripts/Center Controller.cs
+++ b/Assets/Scripts/Center Controller.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public class CenterController : MonoBehaviour
+{
+    public int level;
+    public int energy;
+    public int health;
+    void Start()
+    {
+        
+    }
+
+    void Update()
+    {
+        
+    }
+
+    public bool HaveEnoughEnergy(int energyCost)
+    {
+        return energy >= energyCost;
+    }
+    public void DecreaseEnergy(int energyCost)
+    {
+        energy -= energyCost;
+    }
+    public void DecreaseHealth()
+    {
+        health--;
+        if (health <= 0)
+        {
+            // 輸了
+            // 需要 UI 暫停遊戲並有重新開始的按紐
+        }
+        Debug.Log("Health" + health);
+    }
+    public void NextLevel()
+    {
+        if (level == 5)
+        {
+            // 贏了
+            // 需要 UI 暫停遊戲並有重新開始的按紐
+        }
+        else
+        {
+            // 贏了 1 個 level，需要 UI 暫停遊戲並有下一level的按鈕、重新開始的按鈕
+            level++;
+        }
+    }
+}

--- a/Assets/Scripts/Center Controller.cs.meta
+++ b/Assets/Scripts/Center Controller.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a37fe56153ee66429340838af8608fd

--- a/Assets/Scripts/Zombie/SpawnerManager.cs
+++ b/Assets/Scripts/Zombie/SpawnerManager.cs
@@ -4,7 +4,6 @@ using System.Collections;
 
 public class SpawnerManager : MonoBehaviour
 {
-    public int level = 5;
     public float spawnInterval = 5f;
     public int NormalRate;
     public int GiantRate;
@@ -15,7 +14,9 @@ public class SpawnerManager : MonoBehaviour
     public ZombieSpawner spawner_three;
     public ZombieSpawner spawner_four;
     public float waveDuration;
+    public CenterController centerController;
     ///////////////////////////////////////
+    private int level;
     private float Timer = 0f;
     private float spawnTimer = 0f;
     private int[] rows = { 0, 1, 2, 3, 4 };
@@ -31,6 +32,7 @@ public class SpawnerManager : MonoBehaviour
         cardinalNum = RunnerRate;
         int zombiesLayer = LayerMask.NameToLayer("zombies");
         Physics.IgnoreLayerCollision(zombiesLayer, zombiesLayer, true);
+        level = centerController.level;
         Debug.Log("Ignore zombie layer collision");
     }
 
@@ -39,8 +41,13 @@ public class SpawnerManager : MonoBehaviour
     {
         if (waveTimes < 3) // 3波結束後就不生成殭屍了
         {
+            if (Timer >= 55f)
+            {
+                // 顯示文字在當前 UI "一大波殭屍正在接近"
+            }
             if (Timer >= 60f && waveTimes < 3)
             {
+                // UI "一大波殭屍正在接近" 清除
                 isWave = true;
                 StartCoroutine(waveSpawn());
                 Timer = 0f;
@@ -54,6 +61,20 @@ public class SpawnerManager : MonoBehaviour
             }
             Timer += Time.deltaTime;
             if (!isWave) spawnTimer += Time.deltaTime;
+        }
+        else
+        {
+            // 場中沒殭屍了 通關一個 level
+            //Debug.Log("wait zombie clear" + spawner_zero.IsZombieEmpty() + spawner_one.IsZombieEmpty() + spawner_two.IsZombieEmpty() + spawner_three.IsZombieEmpty() + spawner_four.IsZombieEmpty());
+            if (spawner_zero.IsZombieEmpty() && spawner_one.IsZombieEmpty() && spawner_two.IsZombieEmpty() && spawner_three.IsZombieEmpty() && spawner_four.IsZombieEmpty())
+            {
+                centerController.NextLevel();
+                level = centerController.level;
+                waveTimes = 0;
+                Timer = 0f;
+                spawnTimer = 0f;
+                Debug.Log("Level" + level);
+            }
         }
     }
 

--- a/Assets/Scripts/Zombie/Zombie AI.cs
+++ b/Assets/Scripts/Zombie/Zombie AI.cs
@@ -12,6 +12,7 @@ public class ZombieController : MonoBehaviour
     public Animator animator;
     public float destroyDelay;
     public BoxCollider boxCollider;
+    private CenterController centerController;
     // setting up
     private float speed;
     private float health;
@@ -62,6 +63,8 @@ public class ZombieController : MonoBehaviour
         health = originalHealth;
         attack = originalAttack;
         SetState(State.Walk);
+        centerController = GameObject.Find("Center Controller").GetComponent<CenterController>();
+        if (centerController == null) Debug.Log("Don't find the centerController");
         //TEST_TIMER = TEST_INTERVAL;
     }
 
@@ -92,6 +95,7 @@ public class ZombieController : MonoBehaviour
         if (collision.gameObject.tag == "EndLine")
         {
             Debug.Log("zombie walk to EndLine");
+            centerController.DecreaseHealth();
             DeleteThis(false);
         }
         if (collision.gameObject.tag != "Ground")

--- a/Assets/Scripts/Zombie/ZombieSpawner.cs
+++ b/Assets/Scripts/Zombie/ZombieSpawner.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.NetworkInformation;
 using UnityEngine;
 
@@ -95,5 +96,14 @@ public class ZombieSpawner : MonoBehaviour
         {
             Debug.Log("There isn't have the target zombie");
         }
+        // 清理已經被銷毀的物件
+        Zombies = new LinkedList<GameObject>(Zombies.Where(z => z != null));
+    }
+
+    public bool IsZombieEmpty()
+    {
+        Transform zombie = transform.GetChild(0);
+        //if (zombie.childCount == 0) Debug.Log("can't find zombie");
+        return zombie.childCount == 0;
     }
 }

--- a/Assets/Scripts/item/PeaShooter.cs
+++ b/Assets/Scripts/item/PeaShooter.cs
@@ -42,6 +42,7 @@ public class PeaShooter : MonoBehaviour, Damageable
         {
             DestroyPeaShooter();    
         }
+        Debug.Log("PeaShooter Health" + currentHealth);
     }
 
     private void DestroyPeaShooter()


### PR DESCRIPTION
主要修改了以下部分
* 3次 wave 結束之後便不會再生成殭屍了，如果場中的殭屍被清空，才會將level++並進行下一輪 (上限到5)
* 殭屍撞進EndLine之後，Center Controller裡面存放的health會-1
* 將PeaShooter製作成完整prefab


需要跟進的部分: 
* PeaShooter 可以放進item道具欄了
* Center Controller裡面需要轉換UI
* EnergyCost尚未實作