### PR TITLE
fix anti ground problem

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1292,7 +1292,7 @@ GameObject:
   - component: {fileID: 213245699}
   m_Layer: 0
   m_Name: AntiGround5
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2007,7 +2007,7 @@ GameObject:
   - component: {fileID: 522843228}
   m_Layer: 0
   m_Name: AntiGround4
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2430,7 +2430,7 @@ GameObject:
   - component: {fileID: 650310802}
   m_Layer: 0
   m_Name: AntiGround6
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2980,7 +2980,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   level: 1
   energy: 100
-  health: 15
+  health: 100
   gameOverCanvas: {fileID: 1775969268}
   winCanvas: {fileID: 416876563}
   LpCanvas: {fileID: 1538956979}
@@ -4606,7 +4606,7 @@ GameObject:
   - component: {fileID: 1314668865}
   m_Layer: 0
   m_Name: AntiGround1
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -5012,7 +5012,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.7, y: 2.05, z: 1.35}
-  m_LocalScale: {x: 55, y: 1, z: 1}
+  m_LocalScale: {x: 55, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -5353,7 +5353,7 @@ GameObject:
   - component: {fileID: 1575280441}
   m_Layer: 0
   m_Name: AntiGround3
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6067,7 +6067,7 @@ GameObject:
   - component: {fileID: 1815332465}
   m_Layer: 0
   m_Name: AntiGround2
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6366,7 +6366,7 @@ GameObject:
   - component: {fileID: 1953947440}
   m_Layer: 0
   m_Name: AntiGround
-  m_TagString: Untagged
+  m_TagString: AntiGround
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/Zombie/MinerZombie.cs
+++ b/Assets/Scripts/Zombie/MinerZombie.cs
@@ -86,11 +86,18 @@ public class MinerZombie : MonoBehaviour
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (!firstTouchGround && collision.gameObject.tag == "Ground")
+        if (!firstTouchGround && (collision.gameObject.tag == "Ground"))
         {
             rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ | RigidbodyConstraints.FreezeRotationY;
             backToGroundY = transform.position.y;
             transform.position += new Vector3(0, -1, 0) * 1.5f;
+            firstTouchGround = true;
+        }
+        if (!firstTouchGround &&collision.gameObject.tag == "AntiGround")
+        {
+            rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ | RigidbodyConstraints.FreezeRotationY;
+            backToGroundY = transform.position.y;
+            transform.position += new Vector3(0, -1, 0) * 1.8f;
             firstTouchGround = true;
         }
         if (collision.gameObject.tag == "Bullet")
@@ -106,7 +113,7 @@ public class MinerZombie : MonoBehaviour
             moveDirection = new Vector3(0, 0 , -1);
             return;
         }
-        if (isStand && collision.gameObject.tag != "Ground" && collision.gameObject.tag != "EndLine")
+        if (isStand && collision.gameObject.tag != "Ground" && collision.gameObject.tag != "AntiGround" && collision.gameObject.tag != "EndLine")
         {
             Debug.Log("OnCollisionEnter: " + collision.gameObject.name);
             speed = 0;
@@ -130,7 +137,7 @@ public class MinerZombie : MonoBehaviour
 
     private void OnCollisionExit(Collision collision)
     {
-        if (collision.gameObject.tag != "Ground" && collision.gameObject.tag != "EndLine")
+        if (collision.gameObject.tag != "Ground" && collision.gameObject.tag != "AntiGround" && collision.gameObject.tag != "EndLine")
         {
             Debug.Log("OnCollisionExit: " + collision.gameObject.name);
             speed = originalSpeed;

--- a/Assets/Scripts/Zombie/ZombieAI.cs
+++ b/Assets/Scripts/Zombie/ZombieAI.cs
@@ -99,7 +99,7 @@ public class ZombieController : MonoBehaviour
             centerController.DecreaseHealth();
             DeleteThis(false);
         }
-        if (collision.gameObject.tag != "Ground")
+        if (collision.gameObject.tag != "Ground" && collision.gameObject.tag != "AntiGround")
         {
             Debug.Log("OnCollisionEnter: " + collision.gameObject.name);
             speed = 0;
@@ -146,7 +146,7 @@ public class ZombieController : MonoBehaviour
 
     private void OnCollisionExit(Collision collision)
     {
-        if (collision.gameObject.tag != "Ground")
+        if (collision.gameObject.tag != "Ground" && collision.gameObject.tag != "AntiGround")
         {
             Debug.Log("OnCollisionExit: " + collision.gameObject.name);
             speed = originalSpeed;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - ZombieSpawner
   - item
   - EndLine
+  - AntiGround
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Anti Ground 建太高了而且 tag 不是 Ground，殭屍碰到不是 Ground 的會停下攻擊，所以殭屍都卡在出生點

修改如下
將Anti Ground都加上 AntiGround 的 tag
修改 ZombieAI 以及 MinerZombie，回到原本遊戲狀態
EndLine scale y增加，避免殭屍踩在 AntiGround 上碰撞不到 EndLine